### PR TITLE
Fix typo `IMAGE_NAME_GAR` to use correct secret name

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -38,4 +38,4 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ secrets.gar_dst }}:latest
+            ${{ secrets.IMAGE_NAME_GAR }}:latest


### PR DESCRIPTION
## Why

The name of the secret was wrong... I fixed it.